### PR TITLE
Remove pragma unroll

### DIFF
--- a/rtopk_kernel.cu
+++ b/rtopk_kernel.cu
@@ -16,7 +16,6 @@ __global__ void rtopk_kernel(float *data, float *value, int *index, int N, int d
 
     const int dim_len = (dim_origin + 31) / 32;
 
-    #pragma unroll
     for(int ext = 0; ext < dim_len; ext++){
         cache[wid * dim_origin + laneid + ext * 32] = data[blockIdx.x * WARPS_PER_BLOCK * dim_origin + wid * dim_origin + laneid + ext * 32];
     }
@@ -25,7 +24,6 @@ __global__ void rtopk_kernel(float *data, float *value, int *index, int N, int d
 
     float max_data = -99999, min_data = 99999;
 
-    #pragma unroll
     for(int j = 0; j < dim_len; j++){
         if(cache[wid * dim_origin + laneid + j * 32] > max_data){
             max_data = cache[wid * dim_origin + laneid + j * 32];
@@ -52,7 +50,6 @@ __global__ void rtopk_kernel(float *data, float *value, int *index, int N, int d
 
     for(int i = 0; ; i++){
         count = 0;
-        #pragma unroll
         for(int j = 0; j < dim_len; j++){
             count += cache[wid * dim_origin + laneid + j * 32] >= mid_data;
         }
@@ -93,7 +90,6 @@ __global__ void rtopk_kernel(float *data, float *value, int *index, int N, int d
 
     float thres = close ? max_data : mid_data;
 
-    #pragma unroll
     for(int ext = 0; ext < dim_len; ext++){
         if(total_cnt >= k){
             return;
@@ -116,7 +112,6 @@ __global__ void rtopk_kernel(float *data, float *value, int *index, int N, int d
     }
 
 
-    #pragma unroll
     for(int ext = 0; ext < dim_len; ext++){
         if(total_cnt >= k){
             return;


### PR DESCRIPTION
The `#pragma unroll` [directive](https://github.com/xiexi51/RTopK/blob/main/rtopk_kernel.cu#L28) fails because `dim_len` is not a compile-time constant. Since dim_origin is passed as a runtime kernel argument - not as a template parameter - the compiler cannot determine the value of dim_len at compile time.

Error:
```
# clang++ Flags:
--std=c++17 -O2 -Werror

error: loop not unrolled: the optimizer was unable to perform the requested transformation; 
```

This PR removes `#pragma unroll` lines.


Related issue:
https://github.com/xiexi51/RTopK/issues/3
